### PR TITLE
Patch 5.4 Warlock Destruction Priority List

### DIFF
--- a/defaults/ProtipperWarlock.lua
+++ b/defaults/ProtipperWarlock.lua
@@ -208,7 +208,7 @@ Protipper.SPEC_LIST["Destruction"] = {
         "p.AbilityReady('Conflagrate')" },
 
       { "Incinerate",
-        "p.AbilityReady('Conflagrate')" },
+        "p.AbilityReady('Incinerate') or p.IsCasting('Incinerate')" },
 
       { "Fel Flame",
         "true" },


### PR DESCRIPTION
This fixes this issues with Incinerate not appearing when intended.
