### PR TITLE
Warlock Destruction Priority List for 5.4

### DIFF
--- a/defaults/ProtipperWarlock.lua
+++ b/defaults/ProtipperWarlock.lua
@@ -185,7 +185,9 @@ Protipper.SPEC_LIST["Destruction"] = {
            p.LowOnHealth(0.02, 'target'))]] },
 
       { "Immolate",
-        "p.DotRefresh('Immolate') and (not p.IsCasting('Immolate'))" },
+        [[p.DotRefresh('Immolate') and
+          (not p.IsCasting('Immolate')) and
+          (not p.IsTraveling('Immolate'))]] },
 
       { "Conflagrate",
         [[p.AbilityReady('Conflagrate') and
@@ -201,7 +203,7 @@ Protipper.SPEC_LIST["Destruction"] = {
         "p.AbilityReady('Conflagrate')" },
 
       { "Incinerate",
-        "p.AbilityReady('Conflagrate')" },
+        "p.AbilityReady('Incinerate') or p.IsCasting('Incinerate')" },
 
       { "Fel Flame",
         "true" },


### PR DESCRIPTION
New destruction branch. Fixes #4 again, so I won't bother with reopening it.
