### PR TITLE
Bug: DebuffRefresh and DotRefresh threw nil comparison errors

### DIFF
--- a/Protipper.lua
+++ b/Protipper.lua
@@ -405,7 +405,16 @@ Protipper.DotRefresh = function(spellName)
     local name, rank, icon, powerCost, isFunnel, powerType, castingTime,
         minRange, maxRange = GetSpellInfo(spellName);
 
+    if (castingTime == nil) then
+        castingTime = 0
+        powerCost = 0
+    end
+
     local currentPower = UnitPower("player", powerType);
+
+    if (currentPower == nil) then
+        currentPower = 0
+    end
 
     local _, _, _, count, _, dotDuration, expires, _,
         _, _, spellID, _, _,


### PR DESCRIPTION
When faced with existing debuffs, but no corresponding spells to look up, both `DebuffRefresh` and `DotRefresh` threw errors, which propagated all the way to the user.

This should now be fixed for all the cases mentioned in #33.
