### PR TITLE
A few tweaks to destruction priority list.

### DIFF
--- a/defaults/ProtipperWarlock.lua
+++ b/defaults/ProtipperWarlock.lua
@@ -203,11 +203,15 @@ Protipper.SPEC_LIST["Destruction"] = {
           p.ChargesBetween('Conflagrate', 2, 2)]] },
 
       { "Chaos Bolt",
-        [[(p.AbilityReady('Chaos Bolt') or
-           p.IsCasting('Chaos Bolt')) and
+        [[(p.AbilityReady('Chaos Bolt') and
            (p.PowerBetween('Burning Embers', 4, 4, 'player') or
             p.BuffActive('Skull Banner', 'player') or
-            p.BuffActive('Dark Soul: Instability', 'player'))]] },
+            p.BuffActive('Dark Soul: Instability', 'player')))
+          or
+          (p.IsCasting('Chaos Bolt') and
+           p.PowerBetween('Burning Embers', 2, 4, 'player') and
+           (p.BuffActive('Skull Banner', 'player') or
+            p.BuffActive('Dark Soul: Instability', 'player')))]] },
 
       { "Conflagrate",
         "p.AbilityReady('Conflagrate')" },


### PR DESCRIPTION
`Dark Soul` is now `Dark Soul: Instability` and should work with the upcoming pull request #41 . `Chaos Bolt` should also work as intended now.
