### PR TITLE
Add combo points to return table of api.Status

### DIFF
--- a/Protipper.lua
+++ b/Protipper.lua
@@ -293,6 +293,7 @@ end
     maxHealth - A double representing the units maximum health.
     currentPower - A double representing the units current primary power.
     maxPower - A double representing the units maximum primary power.
+    comboPoints - An integer representing the current number of combo points on the target.
     Perhaps alternate powers?]]
 api.Status = function(unit)
   local status = {}

--- a/Protipper.lua
+++ b/Protipper.lua
@@ -298,6 +298,7 @@ api.Status = function(unit)
   local status = {}
   status.currentHealth, status.maxHealth = UnitHealth(unit), UnitHealthMax(unit)
   status.currentPower, status.maxPower = UnitPower(unit), UnitPowerMax(unit)
+  status.comboPoints = GetComboPoints("player")
   return status
 end
 


### PR DESCRIPTION
This is a simple proposed solution to #62. Closes #62 when merged.

We should probably decide what to do in case you don't have combo points. Do we exclude the table entry entirely, include it with a value like 0, -1, nil, etc.?